### PR TITLE
Be more liberal with final methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 2.0.1
+This version contains minor patches.
+- Method `removeEntriesWithArgument` is now non-final to allow logging in a debugger
+  inheriting from `FiniteCombinatoryLogic`
 ### Version 2.0.0
 This is the first public release of cls-scala.
 The most notable changes to prior (internal development) versions are:

--- a/src/main/scala/org/combinators/cls/inhabitation/FiniteCombinatoryLogic.scala
+++ b/src/main/scala/org/combinators/cls/inhabitation/FiniteCombinatoryLogic.scala
@@ -139,7 +139,7 @@ class FiniteCombinatoryLogic(val subtypes: SubtypeEnvironment, val repository: R
         })
 
   /** Removes all entries of `grammar` where `arg` occurs in a right hand side. */
-  final def removeEntriesWithArgument(grammar: TreeGrammar, arg: Type): TreeGrammar =
+  def removeEntriesWithArgument(grammar: TreeGrammar, arg: Type): TreeGrammar =
     grammar.mapValues(entries => entries.filterNot(_._2.contains(arg)))
 
 


### PR DESCRIPTION
Allow people to override the `removeEntriesWithArgument` method, which is good for debugging